### PR TITLE
Defined ConfigQuery, updated ConfigMap to use it

### DIFF
--- a/src/koala-build/config/ConfigMap.ts
+++ b/src/koala-build/config/ConfigMap.ts
@@ -1,7 +1,10 @@
+import KoalaError from '../KoalaError';
 import IConfigResult from './ConfigResult';
+
+import { IConfigQuery } from './query';
 import Options, { IQueryOptions } from './QueryOptions';
 
-type options_t = IQueryOptions | any | undefined | null;
+export type options_t = IQueryOptions | any | undefined | null;
 
 /**
  * Core interface for config values retrival.
@@ -12,29 +15,27 @@ export interface IConfigMap {
      * @param query The query string.
      * @return The config value matching the query.
      */
-    getValue(query: string, options?: options_t): any;
+    getValue(query: IConfigQuery, options?: options_t): any;
 
     /**
      * Gets a config value matching the given query as a config result.
      * @param query The query string.
      * @return A config result with the value matching the query.
      */
-    get(query: string, options?: options_t): IConfigResult;
+    get(query: IConfigQuery, options?: options_t): IConfigResult;
 }
 
 export default abstract class ConfigMap implements IConfigMap {
-    public getValue(query: string, options?: options_t) {
+    public getValue(query: IConfigQuery, options?: options_t) {
         return this.get(query, options);
     }
 
-    public get(query: string, options?: options_t): IConfigResult {
+    public get(query: IConfigQuery, options?: options_t): IConfigResult {
         const queryOptions = resolveQueryOptions(options);
-
-        // TODO: this should pass a Query object, not a string.
         return this.getCore(query, queryOptions);
     }
 
-    protected abstract getCore(query: string, options: IQueryOptions): IConfigResult;
+    protected abstract getCore(query: IConfigQuery, options: IQueryOptions): IConfigResult;
 }
 
 export function resolveQueryOptions(options: options_t): IQueryOptions {

--- a/src/koala-build/config/query/QueryParser.ts
+++ b/src/koala-build/config/query/QueryParser.ts
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+
+import { IConfigQuery } from '.';
+
+const kdirectiveRegex = /[a-zA-Z0-9_-$]+/;
+
+export interface IQueryParser {
+    parseQuery(query: string): IConfigQuery;
+}
+
+export function isValidKIdentifier(str: string) {
+    return kdirectiveRegex.test(str);
+}
+
+export default class QueryParser implements IQueryParser {
+    public parseQuery(query: string): IConfigQuery {
+        // TODO: create the query parser here
+        throw new Error('Not implemented');
+    }
+}

--- a/src/koala-build/config/query/fluentBuilder.ts
+++ b/src/koala-build/config/query/fluentBuilder.ts
@@ -1,0 +1,40 @@
+import { IConfigQuery } from '.';
+import { IQueryBuilder } from './queryBuilder';
+
+export interface IFluentBuilder {
+    [fragment: string]: IFluentBuilder;
+
+    $optional: IFluentBuilder;
+    $required: IFluentBuilder;
+
+    (): IConfigQuery;
+}
+
+type BuilderFactory = () => IQueryBuilder;
+export default function fluentBuilder(builderFactory: BuilderFactory): IFluentBuilder {
+    const proxyHandler = {
+        get: (target, name) => {
+            if (name in target) {
+                let member = target[name];
+                if (typeof member === 'function')
+                    member();
+
+                return target;
+            }
+
+            // tslint:disable-next-line:variable-name
+            let builder_: IQueryBuilder = target.__builder$__;
+            target.__builder$__ = builder_.get(name);
+
+            return target;
+        },
+        apply: (target, thisArg, argsList) => {
+            return (target.__builder$__ as IQueryBuilder).build();
+        }
+    };
+
+    let builder = builderFactory();
+    let dummy = { __builder$__: builder };
+
+    return new Proxy(dummy, proxyHandler);
+}

--- a/src/koala-build/config/query/index.ts
+++ b/src/koala-build/config/query/index.ts
@@ -1,0 +1,10 @@
+
+export interface IConfigQuery {
+    nameResolver?: string;
+    path: string[];
+
+    typeName?: string;
+    isOptional: boolean;
+
+    directives: string[];
+}

--- a/src/koala-build/config/query/mapWrapper.ts
+++ b/src/koala-build/config/query/mapWrapper.ts
@@ -1,0 +1,90 @@
+import KoalaError from '../../KoalaError';
+import IConfigResult from '../ConfigResult';
+import fluentBuilder from './fluentBuilder';
+
+import { IConfigQuery } from '.';
+import { IConfigMap, options_t } from '../ConfigMap';
+import { IFluentBuilder } from './fluentBuilder';
+import { IQueryBuilder } from './queryBuilder';
+import { IQueryParser } from './QueryParser';
+
+type BuilderFactory = () => IQueryBuilder;
+type query_t = IConfigQuery | ((builder: IFluentBuilder) => IFluentBuilder) | string;
+
+export interface IConfigMapProxy {
+    getValue(query: query_t, options?: options_t): any;
+    get(query: query_t, options?: options_t): IConfigResult;
+
+    getSourceMap(): IConfigMap;
+}
+
+class ConfigMapProxy implements IConfigMapProxy {
+    private readonly _sourceMap: IConfigMap;
+
+    constructor(
+        sourceMap: IConfigMap, 
+        private builderFactory: BuilderFactory = null, 
+        private queryParser: IQueryParser = null
+    ) {
+        if (typeof sourceMap === 'undefined' || sourceMap === null)
+            throw new KoalaError('sourceMap must have a value');
+
+        if (!('get' in sourceMap) || !('getValue' in sourceMap))
+            throw new KoalaError('sourceMap is not a valid ConfigMap');
+
+        this._sourceMap = sourceMap;
+    }
+
+    public getValue(query: query_t, options?: options_t): any {
+        let resolvedQuery = this.resolveQuery(query);
+        return this._sourceMap.getValue(resolvedQuery, options);
+    }
+
+    public get(query: query_t, options?: options_t): IConfigResult {
+        let resolvedQuery = this.resolveQuery(query);
+        return this._sourceMap.get(resolvedQuery, options);
+    }
+
+    public getSourceMap(): IConfigMap {
+        return this._sourceMap;
+    }
+
+    private resolveQuery(query: query_t): IConfigQuery {
+        if (typeof query === 'undefined' || query === null)
+            throw new KoalaError('query must have a value');
+
+        if (typeof query === 'string')
+            return this.resolveQueryFromString(query);
+
+        if (typeof query === 'function')
+            return this.resolveQueryFromFunction(query);
+
+        return query;
+    }
+
+    private resolveQueryFromString(query: string) {
+        if (!this.queryParser)
+            throw new KoalaError('could not resolve query from a string, ' + 
+                                'this operation is not supported by the current proxy');
+
+        return this.queryParser.parseQuery(query);
+    }
+
+    private resolveQueryFromFunction(func: (b: IFluentBuilder) => IFluentBuilder) {
+        if (!this.builderFactory)
+            throw new KoalaError('could not resolve query from fluent expression, ' + 
+                                 'this operation is not supported by the current proxy');
+
+        let builder = fluentBuilder(this.builderFactory);
+        return func(builder)();
+    }
+}
+
+function createMapWrapper(builderFactory: BuilderFactory = null, queryParser: IQueryParser = null) {
+    return function wrapMap(configMap: IConfigMap) {
+        return new ConfigMapProxy(configMap, builderFactory, queryParser);
+    };
+}
+
+const mapWrapper = createMapWrapper;
+export default mapWrapper;

--- a/src/koala-build/config/query/queryBuilder.ts
+++ b/src/koala-build/config/query/queryBuilder.ts
@@ -1,0 +1,130 @@
+import KoalaError from '../../KoalaError';
+
+import { IConfigQuery } from '.';
+import { isValidKIdentifier } from './QueryParser';
+
+export interface IQueryBuilder {
+    get(fragment: string): IQueryBuilder;
+    type(typeName: string): IQueryBuilder;
+
+    optional(): IQueryBuilder;
+    required(): IQueryBuilder;
+    isOptional(optional: boolean): IQueryBuilder;
+
+    useResolver(resolverName: string): IQueryBuilder;
+
+    setDirectives(directives: string | string[]): IQueryBuilder;
+    withDirectives(directives: string | string[]): IQueryBuilder;
+
+    build(): IConfigQuery;
+}
+
+export class DefaultQueryBuilder implements IQueryBuilder {
+    private readonly _path: string[];
+
+    private _typeName: string;
+    private _resolverName: string;
+    private _isOptional: boolean;
+
+    private _directives: string[];
+
+    constructor() {
+        this._path = [];
+        this._isOptional = false;
+        this._directives = [];
+    }
+
+    public get(fragment: string): IQueryBuilder {
+        if (typeof fragment !== 'string' || !fragment.length)
+            throw new KoalaError('fragment must be a non-empty string');
+
+        if (!isValidKIdentifier(fragment))
+            throw new KoalaError('fragment must be a valid identifier');
+
+        this._directives.push(fragment);
+        return this;
+    }
+
+    public type(typeName: string): IQueryBuilder {
+        if (typeName !== null && (typeof typeName !== 'string' || !typeName.length))
+            throw new KoalaError('typeName must be a non-empty string or null');
+
+        if (!isValidKIdentifier(typeName))
+            throw new KoalaError('typeName must be a valid identifier');
+
+        this._typeName = typeName;
+        return this;
+    }
+    
+    public optional(): IQueryBuilder {
+        this._isOptional = true;
+        return this;
+    }
+    
+    public required(): IQueryBuilder {
+        this._isOptional = false;
+        return this;
+    }
+
+    public isOptional(optional: boolean): IQueryBuilder {
+        this._isOptional = optional;
+        return this;
+    }
+    
+    public useResolver(resolverName: string): IQueryBuilder {
+        if (resolverName !== null && (typeof resolverName !== 'string' || !resolverName.length))
+            throw new KoalaError('resolverName must be a non-empty string or null');
+
+        if (!isValidKIdentifier(resolverName))
+            throw new KoalaError('resolverName must be a valid identifier');
+
+        this._resolverName = resolverName;
+        return this;
+    }
+    
+    public setDirectives(directives: string | string[]): IQueryBuilder {
+        let newDirectives = DefaultQueryBuilder.nornalizeDirectives(directives);
+        this._directives = newDirectives;
+
+        return this;
+    }
+    
+    public withDirectives(directives: string | string[]): IQueryBuilder {
+        let newDirectives = DefaultQueryBuilder.nornalizeDirectives(directives);
+        this._directives.push(...newDirectives);
+        
+        return this;
+    }
+
+    public build(): IConfigQuery {
+        // TODO: Validate the config
+
+        return {
+            path: this._path,
+            typeName: this._typeName,
+            nameResolver: this._resolverName,
+            isOptional: this._isOptional,
+            directives: this._directives || []
+        };
+    }
+
+    private static nornalizeDirectives(directives): string[] {
+        let newDirectives: string[] = null;
+        
+        if (!directives)
+            newDirectives = [];
+        else if (Array.isArray(directives))
+            newDirectives = directives;
+        else if (typeof directives === 'string')
+            newDirectives = [ directives ];
+
+        if (!newDirectives)
+            throw new KoalaError('newDirectives must be a string, array of null');
+
+        return newDirectives;
+    }
+}
+
+export default function queryBuilder(): IQueryBuilder {
+    return new DefaultQueryBuilder();
+}


### PR DESCRIPTION
Defined ConfigQuery with the following functionality:
 * A simple builder. (QueryBuilder)
 * A chainable fluent interface. (fluentBuilder)
 * A proxy for ConfigMap to accept queries as strings and fluent
expressions.