### PR TITLE
Locator baseline

### DIFF
--- a/src/koala-build/locators/configLookup.ts
+++ b/src/koala-build/locators/configLookup.ts
@@ -1,11 +1,12 @@
 export enum LookupObject {
-    Environment,
-    Configuration,
-    TargetOs,
-    TargetArch,
-    TargetHost,
-    Option,
-    Fragment
+    Environment = 'ENVIRONMENT',
+    Configuration = 'CONFIGURATION',
+    TargetOs = 'TARGETOS',
+    TargetArch = 'TARGETARCH',
+    TargetHost = 'TARGETHOST',
+    Option = 'OPTION',
+    Fragment = 'FRAGMENT',
+    Baseline = 'BASELINE'
 }
 
 export interface IConfigLookup {


### PR DESCRIPTION
Added the Baseline LookupObject, string enum keys
* Added Baseline to LookupObject
* All members of LookupObject are strings to allow use with indexes

Rewrite of the FsConfigLocator for maintainability
The FsConfigLocator now uses a different options object, instead of pre
defined attributes each LookupObject can be added to the paths dict.
That way support is dynamic and options will be able to pick up any
future additions to LookupObject without any code changes.