### PR TITLE
Typescipt broke enum indexing, temp fix

### DIFF
--- a/src/koala-build/locators/FsConfigLocator.ts
+++ b/src/koala-build/locators/FsConfigLocator.ts
@@ -12,7 +12,7 @@ import JsonConfigProvider from '../providers/JsonConfigProvider';
 import LayeredJsonConfigProvider from '../providers/LayeredJsonConfigProvider';
 
 export interface IFsConfigLocatorOptions {
-    paths: {[obj in LookupObject]: string[]};
+    paths: {[obj: number]: string[]};
 }
 
 /**

--- a/src/koala-build/locators/configLookup.ts
+++ b/src/koala-build/locators/configLookup.ts
@@ -1,12 +1,12 @@
 export enum LookupObject {
-    Environment = 'ENVIRONMENT',
-    Configuration = 'CONFIGURATION',
-    TargetOs = 'TARGETOS',
-    TargetArch = 'TARGETARCH',
-    TargetHost = 'TARGETHOST',
-    Option = 'OPTION',
-    Fragment = 'FRAGMENT',
-    Baseline = 'BASELINE'
+    Environment,
+    Configuration,
+    TargetOs,
+    TargetArch,
+    TargetHost,
+    Option,
+    Fragment,
+    Baseline
 }
 
 export interface IConfigLookup {


### PR DESCRIPTION
obj[ENUM_TYPE] is broken now in typescript, event with the index
signature [k in ENUM_TYPE]: VTYPE. The current fix will make the code
compile again but we need to go back to using the enum as soon as the
compiler is fixed.