### PR TITLE
Fixed FsConfigLocator having defaults under prefix

### DIFF
--- a/src/koala-build/locators/FsConfigLocator.ts
+++ b/src/koala-build/locators/FsConfigLocator.ts
@@ -95,8 +95,8 @@ const defaultOptions: IFsConfigLocatorOptions = {
         [LookupObject.TargetOs]: [defaultTargetPreix, 'os'],
         [LookupObject.TargetArch]: [defaultTargetPreix, 'arch'],
         [LookupObject.TargetHost]: [defaultTargetPreix, 'host'],
-        [LookupObject.Option]: [defaultTargetPreix, 'misc'],
-        [LookupObject.Fragment]: [defaultTargetPreix, 'imports'],
-        [LookupObject.Baseline]: [defaultTargetPreix, '.baseline']
+        [LookupObject.Option]: ['misc'],
+        [LookupObject.Fragment]: ['imports'],
+        [LookupObject.Baseline]: ['.baseline']
     }
 };


### PR DESCRIPTION
Some paths in the default FsConfigLocatorOptions were wrongly under the
default target prefix (targets/).