### PR TITLE
Fixed LayeredJsonConfigProvider bug

### DIFF
--- a/src/koala-build/providers/LayeredJsonConfigProvider.ts
+++ b/src/koala-build/providers/LayeredJsonConfigProvider.ts
@@ -45,7 +45,7 @@ export default class LayeredJsonConfigProvider implements IConfigProvider {
 
     public getConfig(): any {
         const pf = (jpath: string) => JsonConfigProvider.fromFile(jpath);
-        let subfiles = glob.sync('**/*.json');
+        let subfiles = glob.sync('**/*.json', { cwd: this._baseDirectory });
 
         let mergeTarget = { };
         for (let subfile of subfiles) {

--- a/tests/providers/LayeredConfigProvider.test.ts
+++ b/tests/providers/LayeredConfigProvider.test.ts
@@ -6,7 +6,7 @@ import LayeredJsonConfigProvider from 'providers/LayeredJsonConfigProvider';
 import { CONFIG_PATH } from '../common';
 
 describe('LayeredJsonConfigProvider', () => {
-    describe.skip('#getConfig()', () => {
+    describe('#getConfig()', () => {
         const layersPath = path.join(CONFIG_PATH, 'misc/layered-json');
         const provider = new LayeredJsonConfigProvider(layersPath);
 


### PR DESCRIPTION
Fixed the bug where LayeredJsonConfigProvider was probing the wrong directory.
Enabled all tests for LayeredJsonConfigProvider.