### PR TITLE
Fixed improper passing of source reference in ObjectConfigProvider

### DIFF
--- a/src/koala-build/providers/ObjectConfigProvider.ts
+++ b/src/koala-build/providers/ObjectConfigProvider.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 import KoalaError from '../KoalaError';
 import { IConfigProvider } from './ConfigProvider';
 
@@ -12,6 +14,6 @@ export default class ObjectConfigProvider implements IConfigProvider {
     }
 
     public getConfig() {
-        return this._configObj;
+        return _.cloneDeep(this._configObj);
     }
 }

--- a/tests/providers/ObjectConfigProvider.test.ts
+++ b/tests/providers/ObjectConfigProvider.test.ts
@@ -7,11 +7,28 @@ describe('ObjectConfigProvider', () => {
         it('return the source object', () => {
             const object = { key: 'value' };
             const provider = new ObjectConfigProvider(object);
-            
-            expect(provider.getConfig()).to.be.equal(object);
+
+            expect(provider.getConfig()).to.be.deep.equal(object);
         });
 
-        it.skip('keeps the source object immutable', () => {
+        it('has proper deep clone of the object', () => {
+            const object = { key: { key: { key: { key: 'value' } } } };
+            const provider = new ObjectConfigProvider(object);
+
+            expect(provider.getConfig()).to.be.deep.equal(object);
+        });
+
+        it('maintains the source object reference', () => {
+            const object = { key: 'value' };
+            const provider = new ObjectConfigProvider(object);
+
+            expect(provider.getConfig()).to.be.deep.equal(object);
+
+            object.key = 'another value';
+            expect(provider.getConfig()).to.be.deep.equal(object);
+        });
+
+        it('keeps the source object immutable', () => {
             const object = { key: 'value' };
             const provider = new ObjectConfigProvider(object);
             


### PR DESCRIPTION
The `ObjectConfigProvider` now handles the source reference properly:
 1) No derived (from `getConfig`) object can change the source.
 2) Changing the source will affect future calls to `getConfig`