### PR TITLE
Moved raw configs from 'object' to 'ConfigTree's

### DIFF
--- a/src/koala-build/config/ConfigNode.ts
+++ b/src/koala-build/config/ConfigNode.ts
@@ -1,0 +1,98 @@
+import ConfigTree, { IConfigNodeSet } from 'config/ConfigTree';
+import ManagedConfigNodeSet from 'config/ManagedConfigNodeSet';
+
+export default class ConfigNode {
+    private _tree: ConfigTree;
+    private _parent: ConfigNode;
+
+    private _value: any;
+    private _children: ManagedConfigNodeSet;
+
+    constructor(tree: ConfigTree, parent: ConfigNode = null) {
+        this._tree = tree;
+        this._parent = parent;
+
+        this._children = new ManagedConfigNodeSet();
+    }
+
+    public setValue(newValue: any) {
+        this._value = newValue;
+
+        return this;
+    }
+
+    public getValue() {
+        return this._value;
+    }
+
+    public addChild(key: string) {
+        let newChild = new ConfigNode(this._tree, this);
+        this.setChild(key, newChild);
+
+        return newChild;
+    }
+
+    public setChild(key: string, node: ConfigNode) {
+        this._children.setNode(key, node);
+
+        return node;
+    }
+
+    public hasChild(key: string) {
+        return this._children.hasNode(key);
+    }
+
+    public getChild(key: string) {
+        return this._children.getNode(key);
+    }
+
+    public tryGetChild(key: string) {
+        return this.hasChild(key) ? this._children.getNode(key) : undefined;
+    }
+
+    public hasChildren() {
+        return this._children.count > 0;
+    }
+
+    public getRoot(): ConfigNode {
+        if (this.isRoot)
+            return this;
+
+        return this._parent.getRoot();
+    }
+
+    public toObject(): any {
+        if (!this.hasChildren())
+            return this.getValue();
+
+        const root: any = {};
+        for (const childKey in this.children) {
+            if (this.children.hasOwnProperty(childKey)) {
+                const child = this.children[childKey];
+                root[childKey] = child.toObject();
+            }
+        }
+
+        return root;
+    }
+
+    public get isRoot() {
+        return this._parent === null;
+    }
+
+    public get hasParent() {
+        return !this.isRoot;
+    }
+
+    public get graph() {
+        return this._tree;
+    }
+
+    public get parent() {
+        return this._parent;
+    }
+
+    public get children() {
+        return this._children.getSet();
+    }
+}

--- a/src/koala-build/config/ConfigTree.ts
+++ b/src/koala-build/config/ConfigTree.ts
@@ -1,0 +1,47 @@
+import ConfigNode from 'config/ConfigNode';
+import KoalaError from 'KoalaError';
+
+export default class ConfigTree {
+    private _root: ConfigNode;
+
+    constructor() {
+        this._root = new ConfigNode(this);
+    }
+
+    public toObject(): any {
+        return this._root.toObject();
+    }
+
+    public get root() {
+        return this._root;
+    }
+}
+
+export interface IConfigNodeSet {
+    [key: string]: ConfigNode;
+}
+
+export function objectToTree(obj: any) {
+    if (typeof obj !== 'object')
+        throw new KoalaError('obj must be an object');
+
+    const tree = new ConfigTree();
+    if (obj === null)
+        return tree;
+
+    constructNode(tree.root, obj);
+    return tree;
+}
+
+function constructNode(node: ConfigNode, nodeObject: any) {
+    if (typeof nodeObject === 'object' && nodeObject !== null) {
+        for (const key in nodeObject) {
+            if (nodeObject.hasOwnProperty(key)) {
+                const element = nodeObject[key];
+                constructNode(node.addChild(key), element);
+            }
+        }
+    } else {
+        node.setValue(nodeObject);
+    }
+}

--- a/src/koala-build/config/ManagedConfigNodeSet.ts
+++ b/src/koala-build/config/ManagedConfigNodeSet.ts
@@ -1,0 +1,49 @@
+import ConfigNode from 'config/ConfigNode';
+import { IConfigNodeSet } from 'config/ConfigTree';
+import KoalaError from 'KoalaError';
+
+export default class ManagedConfigNodeSet {
+    private _set: IConfigNodeSet;
+    private _nodeCount: number;
+
+    constructor() {
+        this._set = {};
+        this._nodeCount = 0;
+    }
+
+    public setNode(key: string, node: ConfigNode): void {
+        let isAdd = !this.hasNode(key);
+        
+        this._set[key] = node;
+        if (isAdd)
+            this._nodeCount += 1;
+    }
+
+    public deleteNode(key: string) {
+        if (!this.hasNode(key))
+            return;
+
+        delete this._set[key];
+        this._nodeCount -= 1;
+    }
+
+    public hasNode(key: string) {
+        return this._set.hasOwnProperty(key) &&
+               this._set[key] !== undefined;
+    }
+
+    public getNode(key: string) {
+        if (!this.hasNode(key))
+            throw new KoalaError('node set does not contain requested key');
+
+        return this._set[key];
+    }
+
+    public getSet() {
+        return this._set;
+    }
+
+    public get count() {
+        return this._nodeCount;
+    }
+}

--- a/src/koala-build/loaders/ShellsLoader.ts
+++ b/src/koala-build/loaders/ShellsLoader.ts
@@ -7,6 +7,8 @@ import { IConfigLocator } from '../locators/ConfigLocator';
 
 import configLookup, { IConfigLookup, LookupObject } from '../locators/configLookup';
 
+import ConfigTree from 'config/ConfigTree';
+
 export interface ILoaderShell {
     name: string;
     locator: IConfigLocator;
@@ -54,7 +56,7 @@ export default class ShellsLoader implements IConfigLoader {
         this._shells = [];
     }
 
-    public loadSeeds(buildInfo: IBuildInfo): object[] {
+    public loadSeeds(buildInfo: IBuildInfo): ConfigTree[] {
         if (this._shells.length === 0)
             return [];
 
@@ -63,7 +65,7 @@ export default class ShellsLoader implements IConfigLoader {
         return this.loadShells(lookups, true);
     }
 
-    public loadPartial(lookup: IConfigLookup): object[] {
+    public loadPartial(lookup: IConfigLookup): ConfigTree[] {
         return this.loadShells([lookup], false);
     }
 
@@ -78,7 +80,7 @@ export default class ShellsLoader implements IConfigLoader {
         return [ cfConfiguration, cfEnvironment, cfTargetArch, cfTargetOs, cfTargetHost, ...cfOptions ];
     }
 
-    private loadShells(lookups: IConfigLookup[], loadDefaults: boolean): object[] {
+    private loadShells(lookups: IConfigLookup[], loadDefaults: boolean): ConfigTree[] {
         // Here we run the lookup against all the shells.
         // All shells should execute, shell are not fallback chains!
 
@@ -95,7 +97,7 @@ export default class ShellsLoader implements IConfigLoader {
             .filter(obj => obj !== null); // do not return nulls
     }
 
-    private lookupSelect(shell: ILoaderShell, lookup: IConfigLookup): object {
+    private lookupSelect(shell: ILoaderShell, lookup: IConfigLookup): ConfigTree {
         let rootLookup = shell.locator.locate(lookup);
         if (rootLookup === null && shell.fallbackLocator)
             rootLookup = shell.fallbackLocator.locate(lookup);

--- a/src/koala-build/loaders/index.ts
+++ b/src/koala-build/loaders/index.ts
@@ -1,7 +1,9 @@
 import { IBuildInfo } from '../KoalaBuild';
 import { IConfigLookup } from '../locators/configLookup';
 
+import ConfigTree from 'config/ConfigTree';
+
 export interface IConfigLoader {
-    loadSeeds(buildInfo: IBuildInfo): object[];
-    loadPartial(lookup: IConfigLookup): object[];
+    loadSeeds(buildInfo: IBuildInfo): ConfigTree[];
+    loadPartial(lookup: IConfigLookup): ConfigTree[];
 }

--- a/src/koala-build/providers/ConfigProvider.ts
+++ b/src/koala-build/providers/ConfigProvider.ts
@@ -1,4 +1,5 @@
+import ConfigTree from 'config/ConfigTree';
 
 export interface IConfigProvider {
-    getConfig(): any;
+    getConfig(): ConfigTree;
 }

--- a/src/koala-build/providers/FuncConfigProvider.ts
+++ b/src/koala-build/providers/FuncConfigProvider.ts
@@ -1,6 +1,8 @@
 import KoalaError from '../KoalaError';
 import { IConfigProvider } from './ConfigProvider';
 
+import ConfigTree, { objectToTree } from 'config/ConfigTree';
+
 export default class FuncConfigProvider implements IConfigProvider {
     private readonly _func: () => object;
 
@@ -11,7 +13,7 @@ export default class FuncConfigProvider implements IConfigProvider {
         this._func = configFunc;
     }
 
-    public getConfig() {
-        return this._func();
+    public getConfig(): ConfigTree {
+        return objectToTree(this._func());
     }
 }

--- a/src/koala-build/providers/JsonConfigProvider.ts
+++ b/src/koala-build/providers/JsonConfigProvider.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 
 import { IConfigProvider } from './ConfigProvider';
 
+import ConfigTree, { objectToTree } from 'config/ConfigTree';
+
 export default class JsonConfigProvider implements IConfigProvider {
     private readonly _json: string;
     private readonly _jsonAsPath: boolean;
@@ -11,7 +13,11 @@ export default class JsonConfigProvider implements IConfigProvider {
         this._jsonAsPath = isPath;
     }
 
-    public getConfig(): any {
+    public getConfig(): ConfigTree {
+        return objectToTree(this.getRawConfig());
+    }
+
+    public getRawConfig(): any {
         const json = this._jsonAsPath 
             ? JsonConfigProvider.readFile(this._json)
             : this._json;

--- a/src/koala-build/providers/ObjectConfigProvider.ts
+++ b/src/koala-build/providers/ObjectConfigProvider.ts
@@ -3,6 +3,8 @@ import * as _ from 'lodash';
 import KoalaError from '../KoalaError';
 import { IConfigProvider } from './ConfigProvider';
 
+import ConfigTree, { objectToTree } from 'config/ConfigTree';
+
 export default class ObjectConfigProvider implements IConfigProvider {
     private readonly _configObj: object;
 
@@ -13,7 +15,7 @@ export default class ObjectConfigProvider implements IConfigProvider {
         this._configObj = configObj;
     }
 
-    public getConfig() {
-        return _.cloneDeep(this._configObj);
+    public getConfig(): ConfigTree {
+        return objectToTree(_.cloneDeep(this._configObj));
     }
 }

--- a/tests/config/ConfigTree.test.ts
+++ b/tests/config/ConfigTree.test.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import KoalaError from 'KoalaError';
+
+import ConfigNode from 'config/ConfigNode';
+import ConfigTree, { objectToTree } from 'config/ConfigTree';
+
+describe('ConfigTree', () => {
+    describe('#toObject()', () => {
+        const T = (func: (node: ConfigNode) => void) => {
+            const tree = new ConfigTree();
+            func(tree.root);
+
+            return tree;
+        };
+
+        const testSubjects = [
+            { 
+                obj: { a: 'value' }, 
+                tree: T(x => x.addChild('a').setValue('value')) 
+            },
+            {   
+                obj: { a: 'value', b: 'other' }, 
+                tree: T(x => x.addChild('a').setValue('value').parent.addChild('b').setValue('other')) 
+            },
+            {   
+                obj: { a: { b: 'other' } }, 
+                tree: T(x => x.addChild('a').addChild('b').setValue('other')) 
+            }
+        ];
+
+        let i = 1;
+        for (const testSubject of testSubjects) {
+            it(`test subject #${i++}`, () => {
+                const target = testSubject.obj;
+                const source = testSubject.tree.toObject();
+
+                expect(source).to.deep.equal(target);
+            });
+        }
+    });
+});

--- a/tests/config/objectToTree.test.ts
+++ b/tests/config/objectToTree.test.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import { objectToTree } from 'config/ConfigTree';
+import KoalaError from 'KoalaError';
+
+
+describe('objectToTree', () => {
+    it('returns empty tree for null object', () => {
+        const testTree = objectToTree(null);
+        expect(testTree).is.not.null;
+        expect(testTree.root).is.not.null;
+        expect(testTree.root.hasChildren()).is.false;
+        expect(testTree.root.getValue()).is.undefined;
+    });
+
+    it('throws for non object types', () => {
+        expect(() => objectToTree(1)).throws(KoalaError);
+    });
+
+    it('throws for undefined object', () => {
+        expect(() => objectToTree(undefined)).throws(KoalaError);
+    });
+
+    it('maps object root to root node', () => {
+        const testObject = { 'key-in-root': true };
+        const testTree = objectToTree(testObject);
+
+        expect(testTree.root.hasChild('key-in-root')).is.true;
+    });
+
+    it('maps terminal values to node values', () => {
+        const testObject = { 'key-in-root': true };
+        const testTree = objectToTree(testObject);
+
+        expect(testTree.root.getChild('key-in-root').getValue()).is.true;
+        expect(testTree.root.getChild('key-in-root').hasChildren()).is.false;
+    });
+
+    it('maps non-terminal values to sub-nodes', () => {
+        const testObject = { 'key-in-root': { terminal: true } };
+        const testTree = objectToTree(testObject);
+
+        expect(testTree.root.getChild('key-in-root').hasChildren()).is.true;
+    });
+
+    it('does not map non-terminal values to values', () => {
+        const testObject = { 'key-in-root': { terminal: true } };
+        const testTree = objectToTree(testObject);
+
+        expect(testTree.root.getChild('key-in-root').getValue()).is.undefined;
+    });
+});

--- a/tests/loaders/ShellsLoader.test.ts
+++ b/tests/loaders/ShellsLoader.test.ts
@@ -124,7 +124,7 @@ describe('ShellsLoader', () => {
             let seeds = loader.loadSeeds(buildInfo.none);
 
             expect(seeds).to.have.lengthOf(1);
-            expect(seeds[0]).to.have.any.keys('fromDefault');
+            expect(seeds[0].root.hasChild('fromDefault')).is.true;
         });
 
         it('loads configuration in build string', () => {
@@ -133,7 +133,8 @@ describe('ShellsLoader', () => {
             let seeds = loader.loadSeeds(buildInfo.configuration);
 
             expect(seeds).to.have.lengthOf(1);
-            expect(seeds).to.have.deep.members([{ subject: 'configuration' }]);
+            expect(seeds[0].root.hasChild('subject')).is.true;
+            expect(seeds[0].root.getChild('subject').getValue()).equals('configuration');
         });
     });
 

--- a/tests/providers/FuncConfigProvider.test.ts
+++ b/tests/providers/FuncConfigProvider.test.ts
@@ -8,7 +8,7 @@ describe('FuncConfigProvider', () => {
             const func = () => ({ a: 'hello world' });
             const provider = new FuncConfigProvider(func);
             
-            expect(provider.getConfig()).to.have.key('a');
+            expect(provider.getConfig().root.hasChild('a')).is.true;
         });
 
         it('invokes the function every time', () => {
@@ -20,14 +20,14 @@ describe('FuncConfigProvider', () => {
             }
 
             const provider = new FuncConfigProvider(func(0));
-            const firstTime = provider.getConfig() as { b: number };
-            const secondTime = provider.getConfig() as { b: number };
+            const firstTime = provider.getConfig();
+            const secondTime = provider.getConfig();
 
-            expect(firstTime).to.have.key('b');
-            expect(firstTime.b).to.equal(0);
+            expect(firstTime.root.hasChild('b')).is.true;
+            expect(firstTime.root.getChild('b').getValue()).to.equal(0);
 
-            expect(secondTime).to.have.key('b');
-            expect(secondTime.b).to.equal(1);
+            expect(secondTime.root.hasChild('b')).is.true;
+            expect(secondTime.root.getChild('b').getValue()).to.equal(1);
         });
     });
 });

--- a/tests/providers/JsonConfigProvder.test.ts
+++ b/tests/providers/JsonConfigProvder.test.ts
@@ -11,8 +11,8 @@ describe('JsonConfigProvider', () => {
             const jsonPath = path.join(CONFIG_PATH, 'misc/known-state/index.json');
             const provider = JsonConfigProvider.fromFile(jsonPath);
             
-            expect(provider.getConfig()).to.have.key('check');
-            expect(provider.getConfig()['check']).be.equal(true);
+            expect(provider.getConfig().root.hasChild('check')).is.true;
+            expect(provider.getConfig().root.getChild('check').getValue()).is.true;
         });
 
         it('throws if file does not exists', () => {
@@ -26,8 +26,8 @@ describe('JsonConfigProvider', () => {
             const jsonString = `{ "some-key": 123 }`;
             const provider = JsonConfigProvider.fromJson(jsonString);
 
-            expect(provider.getConfig()).to.have.key('some-key');
-            expect(provider.getConfig()['some-key']).be.equal(123);
+            expect(provider.getConfig().root.hasChild('some-key')).is.true;
+            expect(provider.getConfig().root.getChild('some-key').getValue()).eq(123);
         });
 
         it('throws if inline json is invalid', () => {

--- a/tests/providers/LayeredConfigProvider.test.ts
+++ b/tests/providers/LayeredConfigProvider.test.ts
@@ -11,25 +11,27 @@ describe('LayeredJsonConfigProvider', () => {
         const provider = new LayeredJsonConfigProvider(layersPath);
 
         it('reads layers from disk', () => {
-            const resultJson = provider.getConfig() as any;
+            const configTree = provider.getConfig();
 
-            expect(resultJson).to.have.any.keys('i-have-index');
-            expect(resultJson['i-have-index']).be.equal(true);
+            expect(configTree.root.hasChild('i-have-index')).is.true;
+            expect(configTree.root.getChild('i-have-index').getValue()).is.true;
         });
 
         it('merge object from all sources', () => {
-            const resultJson = provider.getConfig() as any;
+            const configTree = provider.getConfig();
+            const subLayer = configTree.root.getChild('sub-layer');
 
-            expect(resultJson['sub-layer']).to.have.all.keys(
-                ['from-named-dir', 'from-index', 'from-named-json']
-            );
+            for (let key of ['from-named-dir', 'from-index', 'from-named-json'])
+                expect(subLayer.hasChild(key)).is.true;
         });
 
         it('named directories keys override named json keys', () => {
-            const resultJson = provider.getConfig() as any;
+            const configTree = provider.getConfig();
+            const configNode = configTree.root
+                .getChild('overrides')
+                .getChild('value-to-override');
 
-            expect(resultJson.overrides).to.have.all.keys('value-to-override');
-            expect(resultJson.overrides['value-to-override']).to.equal('ok');
+            expect(configNode.getValue()).to.equal('ok');
         });
     });
 });

--- a/tests/providers/ObjectConfigProvider.test.ts
+++ b/tests/providers/ObjectConfigProvider.test.ts
@@ -7,37 +7,30 @@ describe('ObjectConfigProvider', () => {
         it('return the source object', () => {
             const object = { key: 'value' };
             const provider = new ObjectConfigProvider(object);
+            const configNode = provider.getConfig().root;
 
-            expect(provider.getConfig()).to.be.deep.equal(object);
+            expect(configNode.hasChild('key')).is.true;
         });
 
         it('has proper deep clone of the object', () => {
             const object = { key: { key: { key: { key: 'value' } } } };
             const provider = new ObjectConfigProvider(object);
+            const configNode = provider.getConfig().root
+                .getChild('key').getChild('key').getChild('key').getChild('key');
 
-            expect(provider.getConfig()).to.be.deep.equal(object);
+            expect(configNode.getValue()).equals('value');
         });
 
         it('maintains the source object reference', () => {
             const object = { key: 'value' };
             const provider = new ObjectConfigProvider(object);
 
-            expect(provider.getConfig()).to.be.deep.equal(object);
+            expect(provider.getConfig().root.getChild('key').getValue())
+                .equals(object.key);
 
             object.key = 'another value';
-            expect(provider.getConfig()).to.be.deep.equal(object);
-        });
-
-        it('keeps the source object immutable', () => {
-            const object = { key: 'value' };
-            const provider = new ObjectConfigProvider(object);
-            
-            let objectFromProvider = provider.getConfig() as any;
-            let otherObjectFromProvider = provider.getConfig() as any;
-            otherObjectFromProvider.key = 'new-value';
-
-            expect(objectFromProvider.key).equals('value');
-            expect(object.key).equals('value');
+            expect(provider.getConfig().root.getChild('key').getValue())
+                .equals(object.key);
         });
     });
 });


### PR DESCRIPTION
All interfaces returning a raw config (before compile) now return config
trees instead of raw Javascript objects. With this change raw configs
are more verbose and config providers can provide a lot more metadata
for loaders and compilers up the chain.